### PR TITLE
ROOT6 compatibility

### DIFF
--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -201,6 +201,8 @@ IF( ROOT_CONFIG_EXECUTABLE )
 
         ENDFOREACH()
 
+	LIST( APPEND _root_libnames Unfold )
+
     ENDIF()
 
 

--- a/src/RooUnfold.cxx
+++ b/src/RooUnfold.cxx
@@ -80,6 +80,7 @@ END_HTML */
 #include "TDecompSVD.h"
 #include "TDecompChol.h"
 #include "TRandom.h"
+#include "TBuffer.h"
 
 #include "../include/RooUnfoldResponse.h"
 #include "../include/RooUnfoldErrors.h"

--- a/src/RooUnfoldResponse.cxx
+++ b/src/RooUnfoldResponse.cxx
@@ -33,6 +33,7 @@
 #include "TH3.h"
 #include "TVectorD.h"
 #include "TMatrixD.h"
+#include "TBuffer.h"
 
 using std::cout;
 using std::cerr;

--- a/src/RooUnfoldSvd.cxx
+++ b/src/RooUnfoldSvd.cxx
@@ -34,6 +34,7 @@ END_HTML */
 #include "TH2.h"
 #include "TVectorD.h"
 #include "TMatrixD.h"
+#include "TBuffer.h"
 #include "../include/TauSVDUnfold.h"
 
 #include "../include/RooUnfoldResponse.h"


### PR DESCRIPTION
Add missing include (ROOT6) -> backward compatible

Additional library dependence (ROOT6) -> not backward compatible, would need a conditional check on the ROOT version 