### PR TITLE
V02 00 01 patches

### DIFF
--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -201,6 +201,8 @@ IF( ROOT_CONFIG_EXECUTABLE )
 
         ENDFOREACH()
 
+	LIST( APPEND _root_libnames Unfold )
+
     ENDIF()
 
 

--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -17,7 +17,7 @@
 #   ROOT_COMPONENT_LIBRARIES    : list of ROOT component libraries
 #   ROOT_${COMPONENT}_FOUND     : set to TRUE or FALSE for each library
 #   ROOT_${COMPONENT}_LIBRARY   : path to individual libraries
-#   
+#
 #
 #   Please note that by convention components should be entered exactly as
 #   the library names, i.e. the component name equivalent to the library
@@ -88,7 +88,7 @@ IF( ROOT_CONFIG_EXECUTABLE )
     # ==============================================
 
     INCLUDE( MacroCheckPackageVersion )
-    
+
     EXECUTE_PROCESS( COMMAND "${ROOT_CONFIG_EXECUTABLE}" --version
         OUTPUT_VARIABLE _version
         RESULT_VARIABLE _exit_code
@@ -105,7 +105,7 @@ IF( ROOT_CONFIG_EXECUTABLE )
     ENDIF()
 
     CHECK_PACKAGE_VERSION( ROOT ${ROOT_VERSION} )
-	
+
 	# find rootcint
 	SET( ROOT_CINT_EXECUTABLE ROOT_CINT_EXECUTABLE-NOTFOUND )
 	MARK_AS_ADVANCED( ROOT_CINT_EXECUTABLE )
@@ -179,7 +179,7 @@ IF( ROOT_CONFIG_EXECUTABLE )
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     IF( _exit_code EQUAL 0 )
-        
+
         # create a list out of the output
         SEPARATE_ARGUMENTS( _aux )
 
@@ -201,7 +201,9 @@ IF( ROOT_CONFIG_EXECUTABLE )
 
         ENDFOREACH()
 
-	LIST( APPEND _root_libnames Unfold )
+        IF(NOT(ROOT_VERSION_MAJOR LESS 6))
+	          LIST( APPEND _root_libnames Unfold )
+        ENDIF()
 
     ENDIF()
 
@@ -263,4 +265,3 @@ ENDIF( ROOT_FOUND )
 # FIND_PACKAGE( ROOT REQUIRED )
 # FIND_PACKAGE( ROOT COMPONENTS geartgeo QUIET )
 SET( ROOT_FIND_REQUIRED )
-

--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -201,7 +201,7 @@ IF( ROOT_CONFIG_EXECUTABLE )
 
         ENDFOREACH()
 
-        IF(NOT(ROOT_VERSION_MAJOR LESS 6))
+        IF(NOT ROOT_VERSION_MAJOR LESS 6)
 	          LIST( APPEND _root_libnames Unfold )
         ENDIF()
 

--- a/cmake/Modules/MacroRootDict.cmake
+++ b/cmake/Modules/MacroRootDict.cmake
@@ -107,7 +107,6 @@ ENDMACRO()
 # returns:
 #       ROOT_DICT_OUTPUT_SOURCES - list containing generated source and other
 #           previously generated sources
-                                    
 # ----------------------------------------------------------------------------
 MACRO( GEN_ROOT_DICT_SOURCE _dict_src_filename )
 
@@ -116,21 +115,36 @@ MACRO( GEN_ROOT_DICT_SOURCE _dict_src_filename )
     # need to prefix all include dirs with -I
     set( _dict_includes )
     FOREACH( _inc ${ROOT_DICT_INCLUDE_DIRS} )
-        SET( _dict_includes "${_dict_includes}\t-I${_inc}")  #fg: the \t fixes a wired string expansion 
+        SET( _dict_includes "${_dict_includes}\t-I${_inc}")  #fg: the \t fixes a wired string expansion
         #SET( _dict_includes ${_dict_includes} -I${_inc} )
     ENDFOREACH()
 
     STRING( REPLACE "/" "_" _dict_src_filename_nosc ${_dict_src_filename} )
     SET( _dict_src_file ${ROOT_DICT_OUTPUT_DIR}/${_dict_src_filename_nosc} )
     STRING( REGEX REPLACE "^(.*)\\.(.*)$" "\\1.h" _dict_hdr_file "${_dict_src_file}" )
-    ADD_CUSTOM_COMMAND(
-        OUTPUT  ${_dict_src_file} ${_dict_hdr_file}
-        COMMAND mkdir -p ${ROOT_DICT_OUTPUT_DIR}
-        COMMAND ${ROOT_CINT_WRAPPER} -f "${_dict_src_file}" -c -p ${ROOT_DICT_CINT_DEFINITIONS} ${_dict_includes} ${ROOT_DICT_INPUT_HEADERS}
-        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-        DEPENDS ${ROOT_DICT_INPUT_HEADERS}
-        COMMENT "generating: ${_dict_src_file} ${_dict_hdr_file}"
-    )
+    IF(ROOT_VERSION_MAJOR LESS 6)
+      ADD_CUSTOM_COMMAND(
+          OUTPUT  ${_dict_src_file} ${_dict_hdr_file}
+          COMMAND mkdir -p ${ROOT_DICT_OUTPUT_DIR}
+          COMMAND ${ROOT_CINT_WRAPPER} -f "${_dict_src_file}" -c -p ${ROOT_DICT_CINT_DEFINITIONS} ${_dict_includes} ${ROOT_DICT_INPUT_HEADERS}
+          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+          DEPENDS ${ROOT_DICT_INPUT_HEADERS}
+          COMMENT "generating: ${_dict_src_file} ${_dict_hdr_file}"
+      )
+    ELSE()
+      STRING(REPLACE ".cxx" "_rdict.pcm" _dict_pcm_file ${_dict_src_file})
+      ADD_CUSTOM_COMMAND(
+          OUTPUT  ${_dict_src_file} ${_dict_hdr_file} ${CMAKE_CURRENT_BINARY_DIR}/libRooUnfold.rootmap ${_dict_pcm_file}
+          COMMAND mkdir -p ${ROOT_DICT_OUTPUT_DIR}
+          COMMAND ${ROOT_CINT_WRAPPER} -f "${_dict_src_file}" -rmf ${CMAKE_CURRENT_BINARY_DIR}/libRooUnfold.rootmap -rml libRooUnfold -c -p ${ROOT_DICT_CINT_DEFINITIONS} ${_dict_includes} ${ROOT_DICT_INPUT_HEADERS}
+          WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+          DEPENDS ${ROOT_DICT_INPUT_HEADERS}
+          COMMENT "generating: ${_dict_src_file} ${_dict_hdr_file} and PCH/rootmap file"
+      )
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libRooUnfold.rootmap" DESTINATION lib)
+      install(FILES ${_dict_pcm_file} DESTINATION lib)
+    ENDIF()
+
     LIST( APPEND ROOT_DICT_OUTPUT_SOURCES ${_dict_src_file} )
 
 ENDMACRO()
@@ -142,5 +156,3 @@ MACRO( GEN_ROOT_DICT_SOURCES _dict_src_filename )
     GEN_ROOT_DICT_SOURCE( ${_dict_src_filename} )
 ENDMACRO()
 # ============================================================================
-
-

--- a/cmake/Modules/MacroRootDict.cmake
+++ b/cmake/Modules/MacroRootDict.cmake
@@ -115,7 +115,7 @@ MACRO( GEN_ROOT_DICT_SOURCE _dict_src_filename )
     # need to prefix all include dirs with -I
     set( _dict_includes )
     FOREACH( _inc ${ROOT_DICT_INCLUDE_DIRS} )
-        SET( _dict_includes "${_dict_includes}\t-I${_inc}")  #fg: the \t fixes a wired string expansion
+        SET( _dict_includes "${_dict_includes}\t-I${_inc}" )  #fg: the \t fixes a wired string expansion
         #SET( _dict_includes ${_dict_includes} -I${_inc} )
     ENDFOREACH()
 

--- a/src/RooUnfold.cxx
+++ b/src/RooUnfold.cxx
@@ -80,6 +80,7 @@ END_HTML */
 #include "TDecompSVD.h"
 #include "TDecompChol.h"
 #include "TRandom.h"
+#include "TBuffer.h"
 
 #include "../include/RooUnfoldResponse.h"
 #include "../include/RooUnfoldErrors.h"

--- a/src/RooUnfoldResponse.cxx
+++ b/src/RooUnfoldResponse.cxx
@@ -33,6 +33,7 @@
 #include "TH3.h"
 #include "TVectorD.h"
 #include "TMatrixD.h"
+#include "TBuffer.h"
 
 using std::cout;
 using std::cerr;

--- a/src/RooUnfoldSvd.cxx
+++ b/src/RooUnfoldSvd.cxx
@@ -34,6 +34,7 @@ END_HTML */
 #include "TH2.h"
 #include "TVectorD.h"
 #include "TMatrixD.h"
+#include "TBuffer.h"
 #include "../include/TauSVDUnfold.h"
 
 #include "../include/RooUnfoldResponse.h"


### PR DESCRIPTION
Patches needed to compile RooUnfold under ROOT6:
- Add missing includes
- Add missing libraries (ROOT6 only)
- Add missing .rootmap + pch file for autoloading / cling export