### PR TITLE
Properly set the c++ standard based on ROOT configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,21 @@ link_directories(${Boost_LIBRARY_DIRS})
 
 #Check the compiler and set the compile and link flags
 set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++11")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+# properly set the C++ standard according to the standard used for the root build
+# Enable C++11 by default if found in ROOT
+message(STATUS "Determining C++ standard ...")
+if(ROOT_HAS_CXX11 AND NOT DISABLE_CXX11)
+  message(STATUS "Enabling C++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
+# Enable C++14 by default if found in ROOT
+if(ROOT_HAS_CXX14 AND NOT DISABLE_CXX14)
+  message(STATUS "Enabling C++14")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+endif()
 # first attempt to make cmake work again on OS X
 if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND (APPLE))
 	MESSAGE(STATUS "** std library for clang: libc++")

--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -268,6 +268,14 @@ IF( ROOT_CONFIG_EXECUTABLE )
         set(ROOT_HAS_CXX14 FALSE)
     endif()
 
+    # Check if ROOT was built with C++14 support
+    if(ROOT_CXX_FLAGS MATCHES "-std=c\\+\\+17" OR ROOT_CXX_FLAGS MATCHES "-std=c\\+\\+1z")
+        message(STATUS "ROOT was built with C++17 support")
+        set(ROOT_HAS_CXX14 TRUE)
+    else()
+        set(ROOT_HAS_CXX14 FALSE)
+    endif()
+
 ENDIF( ROOT_CONFIG_EXECUTABLE )
 
 # Threads library

--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -238,6 +238,36 @@ IF( ROOT_CONFIG_EXECUTABLE )
         MESSAGE( STATUS "Check for libdl.so: ${DL_LIB}" )
     ENDIF()
 
+    # Check for root-config scripts
+    #find_program(ROOT_CONFIG NAMES root-config PATHS ${ROOTSYS}/bin NO_DEFAULT_PATH)
+    #if(NOT ROOT_CONFIG)
+    #    message(FATAL_ERROR "Could not find root-config script.")
+    #endif(NOT ROOT_CONFIG)
+    #mark_as_advanced(ROOT_CONFIG)
+
+    # Setting ROOT compiler flags (except the -I parts) to a variable
+    execute_process(COMMAND ${ROOT_CONFIG_EXECUTABLE} --auxcflags OUTPUT_VARIABLE _ROOT_CXX_FLAGS ERROR_VARIABLE error OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(error)
+        message(FATAL_ERROR "Error retrieving ROOT compiler flags: ${error}")
+    endif(error)
+    string(STRIP "${_ROOT_CXX_FLAGS}" ROOT_CXX_FLAGS)
+
+    # Check if ROOT was built with C++11 support
+    if(ROOT_CXX_FLAGS MATCHES "-std=c\\+\\+11")
+        message(STATUS "ROOT was built with C++11 support")
+        set(ROOT_HAS_CXX11 TRUE)
+    else()
+        set(ROOT_HAS_CXX11 FALSE)
+    endif()
+
+    # Check if ROOT was built with C++14 support
+    if(ROOT_CXX_FLAGS MATCHES "-std=c\\+\\+14" OR ROOT_CXX_FLAGS MATCHES "-std=c\\+\\+1y")
+        message(STATUS "ROOT was built with C++14 support")
+        set(ROOT_HAS_CXX14 TRUE)
+    else()
+        set(ROOT_HAS_CXX14 FALSE)
+    endif()
+
 ENDIF( ROOT_CONFIG_EXECUTABLE )
 
 # Threads library


### PR DESCRIPTION
Adaptions in the cmake file (CMakeLists.txt, cmake/FindRoot.cmake)
taken from AliPhysics cmake files.