### PR TITLE
Changes for Root 6.20.02

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,29 +52,6 @@ MESSAGE(STATUS "** Boost Libraries: ${Boost_LIBRARIES}")
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
-#Check the compiler and set the compile and link flags
-set(CMAKE_BUILD_TYPE Release)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-# properly set the C++ standard according to the standard used for the root build
-# Enable C++11 by default if found in ROOT
-message(STATUS "Determining C++ standard ...")
-if(ROOT_HAS_CXX11 AND NOT DISABLE_CXX11)
-  message(STATUS "Enabling C++11")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif()
-
-# Enable C++14 by default if found in ROOT
-if(ROOT_HAS_CXX14 AND NOT DISABLE_CXX14)
-  message(STATUS "Enabling C++14")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-endif()
-# first attempt to make cmake work again on OS X
-if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND (APPLE))
-	MESSAGE(STATUS "** std library for clang: libc++")
-	set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -stdlib=libc++")
-endif()
-
 # adding the library
 aux_source_directory(${PROJECT_SOURCE_DIR}/src SRC)
 LIST(APPEND SRC ${ROOT_DICT_OUTPUT_SOURCES} )

--- a/cmake/Modules/MacroRootDict.cmake
+++ b/cmake/Modules/MacroRootDict.cmake
@@ -126,7 +126,7 @@ MACRO( GEN_ROOT_DICT_SOURCE _dict_src_filename )
       ADD_CUSTOM_COMMAND(
           OUTPUT  ${_dict_src_file} ${_dict_hdr_file}
           COMMAND mkdir -p ${ROOT_DICT_OUTPUT_DIR}
-          COMMAND ${ROOT_CINT_WRAPPER} -f "${_dict_src_file}" -c -p ${ROOT_DICT_CINT_DEFINITIONS} ${_dict_includes} ${ROOT_DICT_INPUT_HEADERS}
+          COMMAND ${ROOT_CINT_WRAPPER} -f "${_dict_src_file}" ${ROOT_DICT_CINT_DEFINITIONS} ${_dict_includes} ${ROOT_DICT_INPUT_HEADERS}
           WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
           DEPENDS ${ROOT_DICT_INPUT_HEADERS}
           COMMENT "generating: ${_dict_src_file} ${_dict_hdr_file}"
@@ -157,7 +157,7 @@ MACRO( GEN_ROOT_DICT_SOURCE _dict_src_filename )
       ADD_CUSTOM_COMMAND(
           OUTPUT  ${_dict_src_file} ${_dict_hdr_file} ${CMAKE_CURRENT_BINARY_DIR}/libRooUnfold.rootmap ${_dict_pcm_file}
           COMMAND mkdir -p ${ROOT_DICT_OUTPUT_DIR}
-          COMMAND ${ROOT_CINT_WRAPPER} -f "${_dict_src_file}" -rmf ${CMAKE_CURRENT_BINARY_DIR}/libRooUnfold.rootmap -rml libRooUnfold -c -p ${ROOT_DICT_CINT_DEFINITIONS} ${_dict_includes} ${INCPATH} ${HEADERS}
+          COMMAND ${ROOT_CINT_WRAPPER} -f "${_dict_src_file}" -rmf ${CMAKE_CURRENT_BINARY_DIR}/libRooUnfold.rootmap -rml libRooUnfold  ${ROOT_DICT_CINT_DEFINITIONS} ${_dict_includes} ${INCPATH} ${HEADERS}
           WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
           DEPENDS ${ROOT_DICT_INPUT_HEADERS}
           COMMENT "generating: ${_dict_src_file} ${_dict_hdr_file} and PCH/rootmap file"

--- a/src/RooUnfold.cxx
+++ b/src/RooUnfold.cxx
@@ -886,7 +886,7 @@ TH1* RooUnfold::Resize (TH1* h, Int_t nx, Int_t ny, Int_t nz)
   }
 
   if (mod) {
-    h->SetBinsLength();  // Just copies array, which isn't right for overflows or 2D/3D
+    h->Rebuild();  // Just copies array, which isn't right for overflows or 2D/3D
     Int_t s= h->GetSumw2N();
     Int_t ox= mx+1, oy= my+1, oz= mz+1;  // old overflow bin
     Int_t px= nx+1, py= ny+1, pz= nz+1;  // new overflow bin

--- a/test/boost_test.cpp
+++ b/test/boost_test.cpp
@@ -9,7 +9,7 @@ struct GlobalSetup {
 		TH1::AddDirectory(false);
 		gROOT->SetBatch(1);
 		gROOT->ProcessLine("gErrorIgnoreLevel = 1001;");
-		gROOT->ProcessLine("gErrorAbortLevel = 1001;");
+		gROOT->ProcessLine("gErrorAbortLevel = 3001;");
 	}
 	~GlobalSetup() {
 	}


### PR DESCRIPTION
CMakeLists.txt: Possibility to propagate CMAKE_BUILD_TYPE
cmake/Modules/MacroRootDict.cmake: Remove obsolete options -c -p
src/RooUnfold.cxx: Use Rebuild() to increase also the siye of sumw2 array
test/boost_test.cpp: Do not abort in case of warnings