### PR TITLE
Fix made to the Fill function for 3D unfolding

### DIFF
--- a/src/RooUnfoldResponse.cxx
+++ b/src/RooUnfoldResponse.cxx
@@ -496,7 +496,7 @@ Int_t RooUnfoldResponse::Fill(Double_t xr, Double_t yr, Double_t zr, Double_t xt
 		ClearCache();
 	((TH3*) _mes)->Fill(xr, yr, zr, w);
 	((TH3*) _tru)->Fill(xt, yt, zt, w);
-	return _res->Fill(Double_t(FindBin(_mes, xr, yr, zt)) + .5, Double_t(FindBin(_tru, xt, yt, zt)) + .5, w);
+	return _res->Fill(Double_t(FindBin(_mes, xr, yr, zr)) + .5, Double_t(FindBin(_tru, xt, yt, zt)) + .5, w);
 }
 
 Int_t RooUnfoldResponse::FindBin(const TH1* h, Double_t x, Double_t y) {


### PR DESCRIPTION
The Fill function was accessing the wrong bin for the first argument. In the original version of RooUnfold this is cloned from this has been fixed so I am making the same change here.