### PR TITLE
Fix compilation error with freetype

### DIFF
--- a/cmake/Modules/FindROOT.cmake
+++ b/cmake/Modules/FindROOT.cmake
@@ -191,8 +191,8 @@ IF( ROOT_CONFIG_EXECUTABLE )
             # extract libnames from -l compiler flags
             STRING( REGEX REPLACE "^-.(.*)$" "\\1" _libname "${_lib}")
 
-            # fix for some root-config versions which export -lz even if using --noauxlibs
-            IF( NOT _libname STREQUAL "z" )
+            # fix for some root-config versions which export -lz and -lfreetype even if using --noauxlibs
+            IF( NOT _libname STREQUAL "z" AND NOT _libname STREQUAL "freetype" )
 
                 # append all library names into a list
                 LIST( APPEND _root_libnames ${_libname} )


### PR DESCRIPTION
This a for the following a compilation error with ROOT v6-20-08-alice1 and freetype; the underlying cause is that root-config lists -lfreetype even when --noauxlibs is requested.